### PR TITLE
feat: Correct post page dates

### DIFF
--- a/src/posts.md
+++ b/src/posts.md
@@ -8,12 +8,14 @@ Some *rerum vulgarium fragmenta*. A pile of digital loose leaf notes.
 This is the firehose—to help myself actually write stuff out, the bar is fairly low for a post. More polished things might also appear [in a different collection](/topics/).
 
 <ul>
-{%- for post in collections.post reversed -%}
+{% assign sorted_posts = collections.post | sort: "data.modified" | reverse %}
+{%- for post in sorted_posts -%}
   <li>
-    <a href="{{ post.url }}">
-    {% if post.data.title %}{{ post.data.title }}{% elsif post.page.fileSlug %}{{ post.page.fileSlug }}{% endif %}
-    </a>
-    <small>({{ post.data.date | formatDate }})</small>
+    <a href="{{ post.url }}">{% if post.data.title %}{{ post.data.title }}{% elsif post.page.fileSlug %}{{ post.page.fileSlug }}{% endif %}</a>
+    <small>
+    (⊕ {{ post.data.created | formatDate: "en-US" }}{% if post.data.modified > post.data.created %}
+    Δ {{ post.data.created | formatDate: "en-US" }}{% endif %})</small>
+
   </li>
 {%- endfor -%}
 </ul>


### PR DESCRIPTION
Orders posts on the "Posts" page by date modified and spiffs up the date metadata presentation.